### PR TITLE
Add reusable toast notification service and container

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,5 @@
 <app-main-spinner></app-main-spinner>
 <app-main-nav-bar></app-main-nav-bar>
+<app-toast-container></app-toast-container>
 <router-outlet></router-outlet>
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { BrowserModule } from '@angular/platform-browser';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { NgbDropdownModule, NgbModule, NgbNavModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDropdownModule, NgbModule, NgbNavModule, NgbToastModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoginComponent } from './login/login.component';
 import { MainViewComponent } from './main-view/main-view.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -59,6 +59,7 @@ import { NewDebtRequestComponent } from './debt-manager/new-debt-request/new-deb
 import { ActionsComponent } from './debt-manager/submitted-debt-requests/actions/actions.component';
 import { ReceivedRequestsComponent } from './debt-manager/received-requests/received-requests.component';
 import { DebtorActionsComponent } from './debt-manager/received-requests/actions/debtor-actions.component';
+import { ToastContainerComponent } from './toast-container/toast-container.component';
 
 @NgModule({
   declarations: [
@@ -108,7 +109,8 @@ import { DebtorActionsComponent } from './debt-manager/received-requests/actions
     NewDebtRequestComponent,
     ActionsComponent,
     ReceivedRequestsComponent,
-    DebtorActionsComponent
+    DebtorActionsComponent,
+    ToastContainerComponent
   ],
   imports: [
     BrowserModule,
@@ -122,6 +124,7 @@ import { DebtorActionsComponent } from './debt-manager/received-requests/actions
     NoopAnimationsModule,
     ReactiveFormsModule,
     NgbTooltipModule,
+    NgbToastModule,
     DragDropModule
   ],
   providers: [

--- a/src/app/services/toaster.service.ts
+++ b/src/app/services/toaster.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+
+export interface ToastMessage {
+  message: string;
+  header?: string;
+  classname?: string;
+  delay?: number;
+  autohide?: boolean;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ToasterService {
+  public toasts: ToastMessage[] = [];
+  private defaultDelay = 5000;
+
+  show(message: string, options: Omit<ToastMessage, 'message'> = {}) {
+    const toast: ToastMessage = {
+      message,
+      autohide: options.autohide ?? true,
+      delay: options.delay ?? this.defaultDelay,
+      header: options.header,
+      classname: options.classname,
+    };
+    this.toasts = [...this.toasts, toast];
+  }
+
+  remove(toast: ToastMessage) {
+    this.toasts = this.toasts.filter(t => t !== toast);
+  }
+
+  success(message: string, delay?: number) {
+    this.show(message, {
+      header: 'Success',
+      classname: 'bg-success text-light',
+      delay,
+    });
+  }
+
+  failure(message: string, delay?: number) {
+    this.show(message, {
+      header: 'Error',
+      classname: 'bg-danger text-light',
+      delay,
+    });
+  }
+
+  standard(message: string, delay?: number) {
+    this.show(message, {
+      classname: 'bg-light text-dark',
+      delay,
+    });
+  }
+}

--- a/src/app/toast-container/toast-container.component.html
+++ b/src/app/toast-container/toast-container.component.html
@@ -1,0 +1,14 @@
+<div class="toast-wrapper position-fixed top-0 end-0 p-3" aria-live="polite" aria-atomic="true">
+  <ngb-toast
+    *ngFor="let toast of toasterService.toasts"
+    [autohide]="toast.autohide"
+    [delay]="toast.delay"
+    [class]="toast.classname"
+    (hidden)="toasterService.remove(toast)"
+  >
+    <ng-template ngbToastHeader *ngIf="toast.header">
+      {{ toast.header }}
+    </ng-template>
+    {{ toast.message }}
+  </ngb-toast>
+</div>

--- a/src/app/toast-container/toast-container.component.html
+++ b/src/app/toast-container/toast-container.component.html
@@ -1,11 +1,6 @@
 <div class="toast-wrapper position-fixed top-0 end-0 p-3" aria-live="polite" aria-atomic="true">
-  <ngb-toast
-    *ngFor="let toast of toasterService.toasts"
-    [autohide]="toast.autohide"
-    [delay]="toast.delay"
-    [class]="toast.classname"
-    (hidden)="toasterService.remove(toast)"
-  >
+  <ngb-toast *ngFor="let toast of toasterService.toasts" [autohide]="toast.autohide ?? false"
+    [delay]="toast.delay ?? 5000" [class]="toast.classname" (hidden)="toasterService.remove(toast)">
     <ng-template ngbToastHeader *ngIf="toast.header">
       {{ toast.header }}
     </ng-template>

--- a/src/app/toast-container/toast-container.component.scss
+++ b/src/app/toast-container/toast-container.component.scss
@@ -1,0 +1,3 @@
+.toast-wrapper {
+  z-index: 1200;
+}

--- a/src/app/toast-container/toast-container.component.ts
+++ b/src/app/toast-container/toast-container.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { ToasterService } from '../services/toaster.service';
+
+@Component({
+  selector: 'app-toast-container',
+  templateUrl: './toast-container.component.html',
+  styleUrls: ['./toast-container.component.scss']
+})
+export class ToastContainerComponent {
+  constructor(public toasterService: ToasterService) { }
+}


### PR DESCRIPTION
## Summary
- add a toast container component to render ng-bootstrap toasts from the app root
- implement a toaster service with helpers for success, failure, and standard notifications
- register the toast container and ng-bootstrap toast module so notifications are available globally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef359d56548330857f630da760cba7